### PR TITLE
Fix: Remove empty source command

### DIFF
--- a/scripts/kubectl-watch.sh
+++ b/scripts/kubectl-watch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source scripts/terraform-checks.sh || exit 2
-source 
+
 check_env
 check_repo_config
 


### PR DESCRIPTION
- Remove empty source command in `watch-kubectl.sh`.
